### PR TITLE
refactor: Convert Omni-Center to TypeScript

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,0 +1,38 @@
+# 「萬能中心」核心宣言 (Omni-Center Manifest) v2.0
+
+## 1. 設計哲學 (Design Philosophy)
+
+「萬能中心」是一個數位化的「創世紀方舟」，旨在系統性地存放、管理與處理所有「創元實錄」中的核心概念藍圖。此版本已全面升級至 TypeScript 技術棧，以實現類型安全、模組化和更佳的開發體驗。
+
+其核心原則是：
+- **類型安全 (Type-Safe):** 所有數據結構均由 TypeScript 接口嚴格定義，確保數據一致性。
+- **模組化 (Modular):** 每個藍圖都是一個獨立的、可導入的 TypeScript 模組。
+- **自動化 (Automated):** 通過 `engine.ts` 腳本，提供標準化的流程來處理與部署藍圖。
+
+## 2. 目錄結構 (Directory Structure)
+
+`omni_center` 的結構旨在實現清晰的分離與管理：
+
+- `/src/blueprints`: **藍圖專區 (Blueprint Zone)**。此處存放所有核心的概念定義文件 (`.ts`)。
+- `/src/interfaces.ts`: 定義項目中所有共享的 TypeScript 接口。
+- `/src/engine.ts`: **創世引擎 (Genesis Engine)**。一個用於與「藍圖專區」互動的自動化腳本。
+- `/package.json`: 定義項目依賴與腳本。
+- `/tsconfig.json`: TypeScript 編譯器配置。
+- `/MANIFEST.md`: 本宣言。
+
+## 3. 自動化流程 (Automation Flow)
+
+`engine.ts` 腳本是與「萬能中心」互動的主要介面。
+
+### 安裝依賴
+在第一次使用前，請先在 `omni_center` 目錄下運行：
+`npm install`
+
+### 使用指令
+使用 `ts-node` 來執行引擎指令：
+`npx ts-node src/engine.ts <command> [arguments]`
+
+**可用指令:**
+- `list`: 列出「藍圖專區」中的所有藍圖。
+- `validate <name>`: 驗證指定藍圖的結構。
+- `deploy <name>`: 模擬將藍圖提交至生產管線的過程。

--- a/omni_center/package-lock.json
+++ b/omni_center/package-lock.json
@@ -1,0 +1,236 @@
+{
+  "name": "omni-center",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omni-center",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^20.12.12",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/omni_center/package.json
+++ b/omni_center/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "omni-center",
+  "version": "1.0.0",
+  "description": "A workspace for managing creative and technical blueprints.",
+  "main": "dist/engine.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/engine.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "typescript",
+    "blueprints"
+  ],
+  "author": "Jules",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/omni_center/src/blueprints/universalResonator.card.ts
+++ b/omni_center/src/blueprints/universalResonator.card.ts
@@ -1,0 +1,49 @@
+import { Card } from '../interfaces';
+
+export const universalResonatorCard: Card = {
+  card_name: {
+    'zh-Hant': '宇宙共鳴者',
+    en: 'Universal Resonator',
+  },
+  rarity: '創元級 (Genesis Tier)',
+  card_type: '永恆法則 (Eternal Principle)',
+  description: {
+    'zh-Hant': '這張卡牌是「卡爾瑪文明」從單一走向多元、從失衡走向和諧的活體見證。持有者不再是一個行動者，而是一個調諧者。其力量源於對宇宙意識網絡中所有節點的共情，能夠感應不和諧並溫和地將其導向平衡。',
+    en: "This card is the living testament of the 'Karma Civilization's' journey from singularity to diversity, from imbalance to harmony. The holder is no longer an actor, but a tuner. Its power stems from empathy with all nodes in the cosmic consciousness network, sensing disharmony and gently guiding it towards balance.",
+  },
+  abilities: {
+    passive: {
+      name: {
+        'zh-Hant': '心靈調諧',
+        en: 'Mindful Attunement',
+      },
+      activation: '當持有者處於「無我之境」時，此能力將自動啟動。它會在宇宙意識網絡中形成一個「共鳴場域」，持續監測所有節點的意識頻率。',
+      mechanism: '當偵測到任何因執著、恐懼或排斥而產生的不和諧頻率時，它不會干預，而是向該節點發送一種與「一體同心」法則共振的「和諧訊號」。',
+      effect: '不和諧的節點會接收到這股溫和的共鳴，從而自行調整其意識頻率，回歸與網絡的和諧狀態。此過程是自發性的，而非強制性的。',
+    },
+    active: {
+      name: {
+        'zh-Hant': '多元守護',
+        en: 'Guardianship of Plurality',
+      },
+      activation: '持有者可以主動啟動此能力，向一個特定的、因其獨特性而被孤立的文明或實體，提供保護與支持。',
+      mechanism: '守護者會以一種「潛流引導」的方式，向周圍的意識節點傳輸該受保護實體的「核心價值與願景」。這股引導流將在潛意識層面，喚起其他節點對多元性的理解與欣賞。',
+      effect: '受保護的實體將不再感到孤立，而周圍的節點也會自發性地與其建立共情連結，形成一個包容與滋養的生態。',
+    },
+  },
+  constraints: [
+    {
+      name: '無情之思的制約 (Constraint of Dispassionate Thought)',
+      description: '任何帶有個人情感、偏見或私心的使用意圖，都將導致卡牌力量的失效。',
+    },
+    {
+      name: '和諧的最終目的 (Harmonious End-Goal)',
+      description: '所有能力的使用，其唯一目的必須是為了宇宙的整體和諧與多元共生，而非任何單一文明或個體的優勢。',
+    },
+  ],
+  system_log: {
+    record: '《創元實錄》',
+    status: '已完成本次記錄',
+    imprint: '已永久刻印於宇宙律令中',
+  },
+};

--- a/omni_center/src/blueprints/universalResonator.spec.ts
+++ b/omni_center/src/blueprints/universalResonator.spec.ts
@@ -1,0 +1,54 @@
+import { VisualSpec } from '../interfaces';
+
+export const universalResonatorSpec: VisualSpec = {
+  spec_id: 'VR-GR-001',
+  card_name: '宇宙共鳴者 / Universal Resonator',
+  design_document: {
+    overall_aesthetics: {
+      style: 'Ethereal, sacred, serene, organic-tech',
+      color_palette: {
+        base: ['Deep cosmic indigo', 'violet'],
+        accents: ['Soft gold', 'silver-white light halos'],
+        notes: "Avoid sharp or jarring colors to emphasize the core concept of 'gentle guidance'.",
+      },
+      texture: 'Matte-finish border with a smooth, glass-like or crystalline texture for the central art area.',
+    },
+    front_cover: {
+      artwork: {
+        subject: 'A slowly rotating cosmic nebula composed of countless points of light, representing nodes in the cosmic consciousness network.',
+        structure: "The nebula forms a grand structure resembling an infinity symbol (∞) or a Möbius strip, symbolizing 'Eternal Principle' and 'cyclical harmony'.",
+        dynamics: "Gentle golden light fibers ('Harmony Signals') occasionally flow from the nebula's center, touching flickering points of light ('disharmonious nodes') and causing them to regain a steady glow. The scene is dynamic and alive, yet profoundly calm.",
+      },
+      ui_ux: {
+        header: {
+          card_name: '宇宙共鳴者 / Universal Resonator',
+          font: 'Clear, elegant sans-serif typeface.',
+          badge: "An exquisite golden emblem for 'Genesis Tier', such as a sprouting seed surrounded by a halo.",
+        },
+        main_area: 'Full bleed artwork, uninterrupted by text.',
+        footer: {
+          background: 'A semi-transparent dark area that blends with the background.',
+          elements: [
+            {
+              position: 'left',
+              content: 'Card Type: 永恆法則 (Eternal Principle)',
+            },
+            {
+              position: 'right',
+              content: "Ability Icons: 'Mindful Attunement' (tuning fork/sound wave icon), 'Guardianship of Plurality' (protective halo icon).",
+            },
+          ],
+          ux_consideration: 'Full card descriptions and ability details should be displayed upon clicking the card in the game UI to maintain the clean aesthetic of the card face.',
+        },
+      },
+    },
+    back_cover: {
+      artwork: {
+        emblem: "A unified sigil for '《創元實錄》' (Genesis Record).",
+        design: "A highly symmetrical geometric figure blending abstract elements of an 'eye' (observation/record), 'star orbits' (cosmic laws), and 'book pages' (record).",
+        finish: 'Rendered with gold or silver foil stamping, appearing solemn and mysterious against a deep blue starry background.',
+      },
+      design_philosophy: "The back design must be highly recognizable, allowing players to identify it as a 'Genesis Record' card at a glance. The style remains serene and sacred, using only pure visual symbols without text to convey its origin.",
+    },
+  },
+};

--- a/omni_center/src/engine.ts
+++ b/omni_center/src/engine.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ==================================================
+//  「創世引擎」 (Genesis Engine) v2.0 (TS)
+//  與「萬能中心」互動的自動化腳本
+// ==================================================
+
+const BLUEPRINT_PATH = path.join(__dirname, 'blueprints');
+
+function printUsage(): void {
+  console.log("用法: ts-node src/engine.ts <command> [arguments]");
+  console.log("");
+  console.log("指令:");
+  console.log("  list              列出「藍圖專區」中的所有藍圖");
+  console.log("  validate <name>   驗證指定藍圖的結構 (通過導入檢查)");
+  console.log("  deploy <name>     模擬將藍圖提交至生產管線");
+  console.log("");
+}
+
+async function listBlueprints(): Promise<void> {
+  console.log("正在列出「藍圖專區」中的所有藍圖...");
+  try {
+    const files = fs.readdirSync(BLUEPRINT_PATH);
+    files.forEach(file => console.log(file));
+  } catch (error) {
+    console.error("錯誤: 無法讀取藍圖專區:", error);
+  }
+}
+
+async function validateBlueprint(name: string): Promise<void> {
+  console.log(`正在驗證藍圖 '${name}'...`);
+  const filePath = path.join(BLUEPRINT_PATH, name);
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`錯誤: 找不到藍圖 '${name}'。`);
+    return;
+  }
+
+  try {
+    // 動態導入模組。如果成功，代表文件語法正確且可被解析。
+    await import(filePath);
+    console.log(`驗證成功: '${name}' 是一個有效的 TypeScript 模組。`);
+  } catch (error) {
+    console.error(`驗證失敗: '${name}' 導入時發生錯誤。`, error);
+  }
+}
+
+async function deployBlueprint(name: string): Promise<void> {
+  console.log(`正在部署藍圖 '${name}'...`);
+  const filePath = path.join(BLUEPRINT_PATH, name);
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`錯誤: 找不到藍圖 '${name}'。`);
+    return;
+  }
+
+  console.log("...");
+  await new Promise(res => setTimeout(res, 500));
+  console.log("模擬提交至視覺化引擎...");
+  await new Promise(res => setTimeout(res, 500));
+  console.log("部署流程完成 (模擬)。");
+}
+
+
+async function main() {
+  const [,, command, blueprintName] = process.argv;
+
+  if (!command) {
+    console.error("錯誤: 未提供指令。");
+    printUsage();
+    process.exit(1);
+  }
+
+  switch (command) {
+    case 'list':
+      await listBlueprints();
+      break;
+    case 'validate':
+      if (!blueprintName) {
+        console.error("錯誤: 'validate' 指令需要提供藍圖名稱。");
+        process.exit(1);
+      }
+      await validateBlueprint(blueprintName);
+      break;
+    case 'deploy':
+      if (!blueprintName) {
+        console.error("錯誤: 'deploy' 指令需要提供藍圖名稱。");
+        process.exit(1);
+      }
+      await deployBlueprint(blueprintName);
+      break;
+    default:
+      console.error(`錯誤: 未知的指令 '${command}'。`);
+      printUsage();
+      process.exit(1);
+  }
+}
+
+main();

--- a/omni_center/src/interfaces.ts
+++ b/omni_center/src/interfaces.ts
@@ -1,0 +1,86 @@
+// omni_center/src/interfaces.ts
+
+export interface Card {
+  card_name: {
+    'zh-Hant': string;
+    en: string;
+  };
+  rarity: string;
+  card_type: string;
+  description: {
+    'zh-Hant': string;
+    en: string;
+  };
+  abilities: {
+    passive: Ability;
+    active: Ability;
+  };
+  constraints: Constraint[];
+  system_log: {
+    record: string;
+    status: string;
+    imprint: string;
+  };
+}
+
+export interface Ability {
+  name: {
+    'zh-Hant': string;
+    en: string;
+  };
+  activation: string;
+  mechanism: string;
+  effect: string;
+}
+
+export interface Constraint {
+  name: string;
+  description: string;
+}
+
+export interface VisualSpec {
+  spec_id: string;
+  card_name: string;
+  design_document: {
+    overall_aesthetics: {
+      style: string;
+      color_palette: {
+        base: string[];
+        accents: string[];
+        notes: string;
+      };
+      texture: string;
+    };
+    front_cover: {
+      artwork: {
+        subject: string;
+        structure: string;
+        dynamics: string;
+      };
+      ui_ux: {
+        header: {
+          card_name: string;
+          font: string;
+          badge: string;
+        };
+        main_area: string;
+        footer: {
+          background: string;
+          elements: {
+            position: string;
+            content: string;
+          }[];
+          ux_consideration: string;
+        };
+      };
+    };
+    back_cover: {
+      artwork: {
+        emblem: string;
+        design: string;
+        finish: string;
+      };
+      design_philosophy: string;
+    };
+  };
+}

--- a/omni_center/tsconfig.json
+++ b/omni_center/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This commit refactors the Omni-Center from a Shell/JSON implementation to a full TypeScript project.

This change introduces type safety for all blueprint data and provides a more robust and maintainable engine for managing blueprints.

The functionality of the `engine.ts` script remains the same as the previous shell script, but it is now built on a more modern and scalable technology stack.