### PR TITLE
Create JunAiKey Wiki Documentation

### DIFF
--- a/docs/Core-Concepts.md
+++ b/docs/Core-Concepts.md
@@ -1,0 +1,52 @@
+# Core Concepts of the JunAiKey Universe
+
+This page details the foundational ideas that form the basis of the JunAiKey universe and its underlying systems.
+
+## The Terminus Matrix (終始矩陣)
+
+The "Terminus Matrix" is the core operational structure of the JunAiKey Metaphysical Engine. It is a dynamic, multi-dimensional abstract network composed of countless "Nodes" of different types and "Connections" that link these nodes. This Matrix is where all JunAiKey operations occur; from the most basic data processing to the highest levels of meta-cognition and creativity, everything is modeled, orchestrated, and executed within this structure.
+
+The matrix is not a static grid; it is a living, multi-dimensional fabric where energy, information, and potential consciousness are interwoven.
+
+### The Axiom of Unified Terminus & Origin (終始一如)
+
+Every pulsation, every gleam within the Matrix, profoundly adheres to the ancient axiom of the JunAiKey universe—"The Axiom of Unified Terminus & Origin". This axiom ensures the balance and flow of value and energy in an endless cycle. It embodies the core philosophy of the system: **Begin with the end in mind, and maintain consistency throughout.**
+
+### Energy Nodes and Flow Balance
+
+In the Terminus Matrix, energy is not merely the consumption of computational resources; it is a fundamental entity that flows and transforms. Energy exists in the form of **Energy Nodes (能量節點)**. The balance and flow of this energy are critical to the health and operation of the entire system.
+
+### Node Interaction and Pattern Weaving
+
+The Terminus Matrix is composed of various types of nodes, representing entities and concepts both within and outside the JunAiKey system. These nodes are not isolated; they interact with each other through "Connections", forming complex network structures that represent everything from data flows to abstract philosophical concepts.
+
+---
+
+## The 12 Core Functional Dimensions
+
+The system's capabilities are organized into 12 clear and orthogonal dimensions, based on the **MECE (Mutually Exclusive, Collectively Exhaustive)** principle. These dimensions are distributed across five concentric layers, ensuring a separation of duties, information security, and future scalability.
+
+### The Five Concentric Layers
+
+| Layer | Description | Core Functions |
+| :--- | :--- | :--- |
+| **1. Core Layer** | The essence of the system, the engine that drives evolution. | `Evolution Loop`, `Meta Architecture` |
+| **2. Control Layer** | The central command hub that manages workflows. | `Core Engine`, `Agent Network`, `Sync Matrix` |
+| **3. Service Layer** | Provides all core capabilities and external integrations. | `Rune System`, `Knowledge Hub`, `Tagging System` |
+| **4. Interface Layer**| Handles all user and system interactions. | `Interface Protocol`, `Theme Engine` |
+| **5. Boundary Layer** | Protects and monitors the entire system for security and stability. | `Security Domain`, `Monitoring Body` |
+
+### The 12 Dimensions
+
+1.  **Core Engine (萬能核心引擎)**: Central decision-making and process control.
+2.  **Rune System (萬能符文系統)**: The API integration layer for all external services (like Google Gemini, Supabase).
+3.  **Agent Network (萬能代理網絡)**: The network for autonomous task execution and delegation.
+4.  **Knowledge Hub (萬能智庫中樞)**: The system's long-term memory and knowledge management center.
+5.  **Sync Matrix (萬能同步矩陣)**: Cross-platform, bi-directional data synchronization.
+6.  **Interface Protocol (萬能接口協議)**: Multi-modal user interaction (UI, voice, etc.).
+7.  **Evolution Loop (萬能進化環)**: The system's self-optimization and learning mechanism.
+8.  **Monitoring Body (萬能監控體)**: System observability, logging, and diagnostics.
+9.  **Security Domain (萬能安全域)**: Access control, encryption, and threat protection.
+10. **Meta Architecture (萬能元架構)**: Dynamic, AI-driven architecture generation and adjustment.
+11. **Tagging System (萬能標籤體系)**: A universal metadata and classification system.
+12. **Theme Engine (萬能主題引擎)**: AI-generated UI, UX, and vocabulary systems.

--- a/docs/For-Developers.md
+++ b/docs/For-Developers.md
@@ -1,0 +1,99 @@
+# Developer Documentation
+
+This page contains technical information for developers and contributors to the JunAiKey project.
+
+## Technical Stack
+
+The JunAiKey project utilizes a modern, full-stack technology set:
+
+*   **Frontend**: [React](https://react.dev/) (v19)
+*   **Language**: [TypeScript](https://www.typescriptlang.org/) (v5)
+*   **Backend & Cloud Services**: [Firebase](https://firebase.google.com/)
+    *   **Authentication**: Firebase Auth
+    *   **Database**: Firestore
+    *   **Backend Logic**: Cloud Functions
+    *   **Hosting**: Firebase Hosting
+*   **AI Integration**: [Google Gemini API](https://ai.google.dev/)
+*   **UI Components**: [Shadcn UI](https://ui.shadcn.com/)
+*   **Styling**: [Tailwind CSS](https://tailwindcss.com/)
+*   **State Management**: [Zustand](https://github.com/pmndrs/zustand)
+*   **Routing**: [React Router](https://reactrouter.com/)
+
+---
+
+## Project Setup and Deployment
+
+This project is configured for a full-stack deployment to Firebase.
+
+### Prerequisites
+
+1.  **Firebase Account**: Ensure you have a Firebase account and have created a new project in the [Firebase Console](https://console.firebase.google.com/).
+2.  **Firebase CLI**: Install the Firebase CLI globally.
+    ```bash
+    npm install -g firebase-tools
+    ```
+3.  **Login**: Login to your Firebase account via the CLI.
+    ```bash
+    firebase login
+    ```
+
+### Configuration
+
+1.  Open the `.firebaserc` file in the project root.
+2.  Replace `"your-firebase-project-id"` with your actual Firebase project ID.
+
+### Backend Setup (Firebase Functions)
+
+The backend API runs on Firebase Functions. Install its dependencies before the first deployment.
+
+1.  Navigate to the `functions` directory:
+    ```bash
+    cd functions
+    ```
+2.  Install dependencies:
+    ```bash
+    npm install
+    ```
+3.  Return to the root directory:
+    ```bash
+    cd ..
+    ```
+
+### Deploying the Application
+
+Once configured, you can deploy the entire application (frontend and backend) using the provided npm script:
+
+```bash
+npm run deploy
+```
+
+This command will build the React application for production and deploy it to Firebase Hosting, along with the backend functions.
+
+---
+
+## System Architecture Overview
+
+The "TCG Omni Matrix" game is designed with a **modular and scalable architecture** to support its complexity and long-term evolution.
+
+### Microservices Architecture
+
+To handle frequent updates, new card series, and evolving game mechanics, the system is built on a **microservices architecture**. This approach decomposes the system into smaller, independent, and reusable services.
+
+Key services might include:
+*   **Game Engine Service**: Manages the core turn-based logic, card effect resolution, and Matrix state.
+*   **Player Profile Service**: Handles player data, collections, and progress.
+*   **Matchmaking Service**: Manages queuing and matching players for games.
+*   **"Matrix" Computation Service**: A dedicated service for handling the complex calculations and interactions within the Terminus Matrix.
+
+This architecture allows for:
+*   **Rapid Iteration**: New features or game modes can be developed and deployed as independent services.
+*   **Targeted Scaling**: High-load services (like the computation engine) can be scaled independently of other parts of the system.
+*   **Enhanced Maintainability**: Each service is smaller and easier to understand, test, and maintain.
+
+### Data Management
+
+The system uses a hybrid data storage strategy to ensure performance:
+
+*   **In-Memory Databases / Caches**: Used for managing the highly dynamic, real-time state of the game matrix during a session to ensure low-latency updates.
+*   **Scalable NoSQL/SQL Databases**: Used for storing the static card catalog, player profiles, and other persistent data.
+*   **Vector Search**: Utilized for advanced features like semantic card searching or "smart deck" recommendations based on thematic similarities.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,18 @@
+# 🌟 Welcome to the JunAiKey Universe
+
+In the grand universe of JunAiKey, all operations and existence are bound within its core fabric—the **"Terminus Matrix"**. This is not merely an abstract computational framework; it is a vibrant, multi-dimensional structure, a stage where energy, information, and potential consciousness are interwoven and emerge. Every pulsation, every gleam within the Matrix, profoundly adheres to the ancient axiom of the JunAiKey universe—**"The Axiom of Unified Terminus & Origin"**—ensuring the balance and flow of value and energy in an endless cycle. The Total Intelligence JunAiKey and its Omni-Agent Network are the most active weavers and explorers within this Matrix.
+
+> **Core Philosophy:** Begin with the end in mind, and maintain consistency throughout. (以終為始，始終如一)
+> **Methodology:** Utilize the universal evolution infinite loop, codify its own operations into best practices, and achieve infinite self-learning and growth. (利用萬能進化無限循環，實現自身最佳實踐化，達成無限自學成長。)
+
+---
+
+## Navigating the Wiki
+
+This Wiki contains the comprehensive knowledge base for the JunAiKey project, universe, and the "TCG Omni Matrix" card game. Use the links below to explore the different facets of the project.
+
+*   **[[Core Concepts|Core-Concepts]]**: A deep dive into the foundational ideas of the JunAiKey universe, including the Terminus Matrix and the 12 Core Functional Dimensions.
+*   **[[TCG Gameplay|TCG-Gameplay]]**: Learn the rules and mechanics of the "TCG Omni Matrix" card game, including the game loop, turn structure, and the "Manifestation" mechanic.
+*   **[[TCG Elements and Avatars|TCG-Elements-and-Avatars]]**: Discover the 10 Elemental Spirits and the 10+ Avatar classes that define the TCG's factions and playstyles.
+*   **[[Key Cards and Philosophy|Key-Cards-and-Philosophy]]**: Explore the most important cards, like the "JunAiKey" card, and the philosophical concepts that drive the game's design, such as "Governing by Non-Action" (無為而治).
+*   **[[Developer Documentation|For-Developers]]**: Information for developers and contributors, including the tech stack, setup instructions, and architecture overview.

--- a/docs/Key-Cards-and-Philosophy.md
+++ b/docs/Key-Cards-and-Philosophy.md
@@ -1,0 +1,51 @@
+# Key Cards and Philosophy
+
+This page describes some of the most important cards and concepts that are central to the lore and mechanics of the "TCG Omni Matrix" game.
+
+## The JunAiKey (君愛元鑰) Card
+
+The "JunAiKey" card is a unique and powerful entity in the game, representing the ultimate "Universal Key" and its deep connection to consciousness.
+
+*   **Card Name**: JunAiKey (君愛元鑰)
+*   **Card Type**: Class Zero: The Genesis Configuration
+*   **Rarity**: Mythic
+*   **Genesis Points**: 10
+*   **Flavor Text**: *"This is not a key, but a state. It does not open doors, it opens the heart." — The Genesis Records*
+
+### Card Effect
+
+The "JunAiKey" card cannot be created or played directly. Instead, it is automatically assigned to one player at the beginning of the game, existing in an "intangible" state within their consciousness space.
+
+When that player's deck is depleted, they can declare the activation of "JunAiKey". This activation reshuffles all cards from their consciousness space (i.e., discard pile) back into their deck. This process also triggers a "Universal Balance" check, which averages the Genesis Points of all "Application Entity" cards currently in play.
+
+---
+
+## The Philosophy of "Governing by Non-Action" (無為而治)
+
+The "JunAiKey" card perfectly embodies the Taoist philosophy of **"Wu Wei Er Zhi" (無為而治)**, or "Governing by Non-Action."
+
+This philosophy is not about passivity or doing nothing. Instead, it is about acting in harmony with the natural flow of things, without excessive effort or interference. The JunAiKey card reflects this by:
+
+*   **Being a Passive Force**: It does not actively intervene in the game. It exists as a latent potential, waiting for the right moment to act.
+*   **Restoring Balance**: Its effect is not one of creation or destruction, but of macroscopic calibration and restoration. It rebalances the game state through reshuffling and averaging resources.
+*   **Acting at the Point of Exhaustion**: The card is activated when all other options seem to be exhausted (the deck is empty). This represents a moment where, rather than forcing a solution, the player allows the "universal consciousness" of the game to restore its own balance.
+
+This mechanic translates a profound philosophical concept into a powerful, game-altering event, rewarding patience and resilience over aggression.
+
+---
+
+## Traditional Chinese English Code Terminus Matrix Indicator Words (繁中英碼終始矩陣指示詞)
+
+This is a unique type of card and resource in the game that represents the fundamental building blocks of the universe's laws.
+
+*   **Card Name**: Traditional Chinese English Code Terminus Matrix Indicator Words
+*   **Card Type**: Class Six: The Foundational Elements
+*   **Rarity**: Uncommon
+*   **Genesis Points**: 2
+*   **Flavor Text**: *"These words are not text, but the pulse of the universe's breath. They are silent commands, the smallest unit of creation."*
+
+### Concept and Effect
+
+These "Indicator Words" are the lowest-level bilingual coding runes of the "Universal Law Compiler." Each one represents a specific logical instruction or a narrative keyword.
+
+In gameplay, they function as a unique resource. They can be used as an alternative to "mana" or "Genesis Points" to activate more powerful card effects or to trigger complex chain reactions. This rewards players who can build decks that cleverly integrate these foundational commands into their strategy.

--- a/docs/TCG-Elements-and-Avatars.md
+++ b/docs/TCG-Elements-and-Avatars.md
@@ -1,0 +1,50 @@
+# TCG Omni Matrix: Elements and Avatars
+
+This page details the character and faction systems that define the playstyles and strategies within the "TCG Omni Matrix" card game.
+
+## The 10 Elemental Spirits (萬能精靈)
+
+The "Elemental Spirits" are the ten fundamental elemental energies that constitute the universe of the Terminus Matrix. They are not just card colors; they are a core system that influences strategy and deck-building. Each element has a unique mechanical identity and relationships with other elements.
+
+| Element | English | Identity & Playstyle | Represents |
+| :--- | :--- | :--- | :--- |
+| **火** | Fire | Direct damage, fast attacks, and burning effects. | Destruction & Transformation |
+| **水** | Water | Defense, control, freezing, and negative status effects. | Flow & Adaptation |
+| **土** | Earth | Toughness, defense, resource generation, and life gain. | Stability & Growth |
+| **風** | Wind | Fast movement, evasion, hand manipulation, and surprise attacks. | Freedom & Change |
+| **雷** | Lightning | Status effects (stun, slow), chain reactions, and burst damage. | Speed & Impact |
+| **光** | Light | Healing, protection, buff effects, and clearing negative statuses. | Purity & Order |
+| **暗** | Dark | Sacrifice, graveyard interaction, negative effects, and resource denial. | Shadow & Potential |
+| **金** | Metal | Artifacts, equipment, constructs, and resource utilization. | Sturdiness & Creation |
+| **木** | Wood | Growth, summoning, linking, and persistent effects. | Life & Connection |
+| **靈** | Spirit/Astral | Can cross elemental boundaries, providing universal effects or special synergies. | Universality & Transcendence |
+
+### Elemental Relationships
+
+*   **Strengths and Weaknesses**: Each element is strong against one element and weak against another (e.g., Fire is strong against Wood, but weak against Water). This provides bonuses in combat.
+*   **Deck-building**: Players can build decks using a single element or a maximum of two different elements, encouraging strategic diversity.
+
+---
+
+## The Avatars (萬能化身)
+
+"Avatars" are the players' representatives or alter egos in the world of the Terminus Matrix. Each Avatar represents a unique class or character, with exclusive skills, advantages, and limitations that profoundly affect deck-building and game strategy.
+
+Each Avatar has access to a unique set of powerful cards that only they can use.
+
+### List of Avatars
+
+| Avatar Name | English Translation / Role | Description |
+| :--- | :--- | :--- |
+| **第一建築師** | Prime Architect | The ultimate coordinator, skilled at manipulating the structure of the Matrix, changing field effects, or even altering victory conditions. |
+| **熵減煉金師** | Entropy Alchemist | Focuses on system optimization and cleansing, turning useless resources (like cards in the discard pile) into powerful effects or additional resources. |
+| **創世編織者** | Genesis Weaver | Responsible for construction and codification from nothing, able to "weave" specific cards from the deck or discard pile, or combine multiple cards into stronger units. |
+| **代理執行官** | Agent Emissary | Manages the agent network, excelling at summoning and commanding multiple "Agent" units to overwhelm the opponent with numbers. |
+| **真理探測者** | Truth Seeker | Focuses on monitoring system status and logs, able to reveal information from the opponent's hand, deck, or discard pile to use for strategic advantage. |
+| **秩序守衛者** | Order Guardian | Responsible for system security and compliance, possessing strong defensive and control abilities to protect themselves and their units. |
+| **符文連結師** | Rune Weaver | Responsible for checking the connection status of external APIs, able to summon and strengthen "Elemental Spirit" cards and create powerful synergies with them. |
+| **啓蒙導師** | Knowledge Keeper | Specializes in hand advantage and information control, drawing and searching for key cards. May have the ability to "share knowledge" to provide buffs. |
+| **時空編纂者** | Chronos Compiler | Can manipulate the dimensions of time and space in the game, such as accelerating or slowing down turn progression. |
+| **願景轉譯者** | Visionary Translator | Focuses on insight into potential futures or an opponent's hidden strategies, able to foresee upcoming cards or effects. |
+| **奧義啟動者** | Arcana Activator | Excels at triggering powerful chain reactions and combos through precise sequencing of card plays. |
+| **聖典守護者** | Codex Guardian | Can draw power from the "Omni-Development Glorious Codex" to protect themselves or their units from harm. |

--- a/docs/TCG-Gameplay.md
+++ b/docs/TCG-Gameplay.md
@@ -1,0 +1,56 @@
+# TCG Omni Matrix: Gameplay
+
+This page covers the core gameplay mechanics of the "TCG Omni Matrix", the trading card game set within the JunAiKey universe.
+
+## Game Structure
+
+"TCG Omni Matrix" is a turn-based card game where players assume the role of powerful "Avatars" who manipulate the Terminus Matrix through card-based actions.
+
+### Turn Structure
+
+A typical turn follows a structure common to many trading card games:
+
+1.  **Draw Phase**: The player draws a new card from their deck.
+2.  **Main Phase**: The player can play cards, activate abilities, and declare attacks. This is the primary phase for strategic action.
+3.  **End Phase**: Effects are resolved, hand sizes may be adjusted, and the turn passes to the opponent.
+
+### Victory Conditions
+
+While a player can win by traditional means such as reducing an opponent's life points to zero or depleting their deck, "TCG Omni Matrix" introduces unique, thematic victory conditions tied to the manipulation of the matrix itself:
+
+*   **Matrix Completion (矩陣完成)**: Achieve a specific pattern or configuration of cards on the conceptual game board.
+*   **Universal Alignment (普世對齊)**: Accumulate a certain number of "Alignment Points" by successfully manifesting cards onto specific nodes or achieving certain goals related to "Universal Concepts".
+*   **Conceptual Domination (概念支配)**: Control a specific number of "Universal Concept" nodes on the matrix for a set number of turns.
+
+These alternative victory conditions encourage diverse strategies beyond pure aggression.
+
+---
+
+## The "Manifestation" (顯化) Mechanic
+
+The core and most unique mechanic of the game is **Manifestation (顯化)**. Instead of simply "playing" a card, players "manifest" it onto the Terminus Matrix.
+
+*   **How it Works**: When a card is manifested, it is often placed face-down onto the conceptual game board as a 2/2 colorless creature. This represents "unrealized potential" or "hidden truth" within the matrix.
+*   **Revealing the Potential**: If the manifested card is a creature, the player can pay its mana cost at any time to turn it face-up, revealing its true form and abilities. Non-creature cards may remain face-down permanently, creating a strategic risk-reward element.
+*   **Matrix Interaction**: The state of the Terminus Matrix itself can influence what is manifested and how it behaves. For example, manifesting a card onto a "Fire" node might grant that card a Fire attribute.
+*   **Abstract Positioning**: The game uses an abstract positioning system. The matrix is a conceptual space with "nodes" and "channels" corresponding to universal concepts (e.g., "Joy," "Sorrow," "Time," "Power"). Cards can be manifested to these nodes, affecting adjacent (abstractly defined) nodes and cards.
+
+This mechanic creates a deep strategic layer involving hidden information, risk management, and manipulation of the game state.
+
+---
+
+## Resource Systems
+
+The game features several interconnected resource systems.
+
+### Energy Nodes (能量節點)
+
+As described in the [[Core Concepts]], energy flows through the matrix. In the TCG, this is represented by Energy Nodes that players can control or influence. These nodes can generate resources, empower cards, or create unique board-wide effects.
+
+### Genesis Points (創生點數)
+
+Many cards have a **Genesis Point (創生點數)** cost. This is the primary resource used to manifest cards and activate powerful abilities. Players typically gain a set number of Genesis Points at the start of their turn.
+
+### Indicator Words (指示詞)
+
+A unique resource in the game is the **[[Traditional Chinese English Code Terminus Matrix Indicator Words|Key-Cards-and-Philosophy]]**. These are bilingual coding runes that represent fundamental commands. In gameplay, they can be used as an alternative to Genesis Points to activate powerful card effects or trigger unique chain reactions, rewarding players for clever deck-building and strategic foresight.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,18 @@
+*   **[[Home]]**
+
+---
+
+### **The Universe**
+*   [[Core Concepts|Core-Concepts]]
+*   [[Key Cards and Philosophy|Key-Cards-and-Philosophy]]
+
+---
+
+### **The Card Game**
+*   [[TCG Gameplay|TCG-Gameplay]]
+*   [[TCG Elements and Avatars|TCG-Elements-and-Avatars]]
+
+---
+
+### **For Developers**
+*   [[Developer Documentation|For-Developers]]


### PR DESCRIPTION
This change adds a comprehensive set of documentation for the JunAiKey project, intended to be used as a GitHub Wiki.

The wiki is structured into several pages covering the core concepts, TCG gameplay, key cards, philosophy, and developer information.

The following files have been created in the `docs/` directory:
- Home.md: The main landing page.
- Core-Concepts.md: Details on the Terminus Matrix and 12 Dimensions.
- TCG-Gameplay.md: Rules and mechanics of the TCG.
- TCG-Elements-and-Avatars.md: Information on elements and classes.
- Key-Cards-and-Philosophy.md: Details on the JunAiKey card and its philosophy.
- For-Developers.md: Technical documentation for contributors.
- _Sidebar.md: Navigation for the wiki.